### PR TITLE
Tests: Define `$api_data` in data providers

### DIFF
--- a/tests/phpunit/tests/Lite/Lite_UpdateSiteTransientTest.php
+++ b/tests/phpunit/tests/Lite/Lite_UpdateSiteTransientTest.php
@@ -172,7 +172,7 @@ class Lite_UpdateSiteTransientTest extends GitUpdater_UnitTestCase {
 	 *
 	 * @dataProvider data_theme_transient_keys_and_api_data
 	 *
-	 * @param string   $key_name      The name of the key.
+	 * @param string   $key_name The name of the key.
 	 * @param stdClass $api_data The API data.
 	 * @param mixed    $expected The expected value.
 	 */
@@ -337,32 +337,11 @@ class Lite_UpdateSiteTransientTest extends GitUpdater_UnitTestCase {
 	 *
 	 * @dataProvider data_plugin_no_update_properties
 	 *
-	 * @param string $property_name The name of the property.
-	 * @param string $expected      The expected value.
+	 * @param string   $property_name The name of the response property to test.
+	 * @param stdClass $api_data      The API data to use.
+	 * @param string   $expected      The expected value.
 	 */
-	public function test_should_add_plugin_response_to_no_update_when_no_update_is_available( $property_name, $expected ) {
-		$api_data = (object) array(
-			'slug'          => 'test-plugin-slug',
-			'file'          => 'my-plugin/my-plugin.php',
-			'type'          => 'plugin',
-			'url'           => 'http://example.org',
-			'version'       => '0.0.1',
-			'icons'         => (object) array(
-				'1x' => 'icon-1x.png',
-				'2x' => 'icon-2x.png',
-			),
-			'banners'       => (object) array(
-				'low'  => 'banner-low.png',
-				'high' => 'banner-high.png',
-			),
-			'branch'        => 'test-branch',
-			'git'           => 'test-githost',
-			'requires'      => 'test-version',
-			'requires_php'  => 'test-php-version',
-			'download_link' => 'test-download-link',
-			'tested'        => '10.0.0',
-		);
-
+	public function test_should_add_plugin_response_to_no_update_when_no_update_is_available( $property_name, $api_data, $expected ) {
 		$lite = new \Fragen\Git_Updater\Lite( $this->test_files['plugin'] );
 		$this->set_property_value( $lite, 'api_data', $api_data );
 
@@ -407,24 +386,6 @@ class Lite_UpdateSiteTransientTest extends GitUpdater_UnitTestCase {
 			"The transient's response value does not have a '{$property_name}' property."
 		);
 
-		if ( is_array( $expected ) ) {
-			$expected = implode(
-				'-',
-				array_map(
-					static function ( $property ) use ( $api_data ) {
-						return $api_data->$property;
-					},
-					$expected
-				)
-			);
-		} elseif ( is_string( $expected ) ) {
-			if ( 'icons' === $expected ) {
-				$expected = (array) $api_data->$expected;
-			} else {
-				$expected = $api_data->$expected;
-			}
-		}
-
 		$this->assertSame(
 			$expected,
 			$actual->no_update[ $api_data->file ]->$property_name,
@@ -438,71 +399,10 @@ class Lite_UpdateSiteTransientTest extends GitUpdater_UnitTestCase {
 	 * @return array[]
 	 */
 	public function data_plugin_no_update_properties() {
-		return array(
-			'slug'             => array(
-				'property_name' => 'slug',
-				'expected'      => 'slug',
-			),
-			'plugin'           => array(
-				'property_name' => 'plugin',
-				'expected'      => 'file',
-			),
-			'url'              => array(
-				'property_name' => 'url',
-				'expected'      => 'url',
-			),
-			'icons'            => array(
-				'property_name' => 'icons',
-				'expected'      => 'icons',
-			),
-			'banners'          => array(
-				'property_name' => 'banners',
-				'expected'      => 'banners',
-			),
-			'branch'           => array(
-				'property_name' => 'branch',
-				'expected'      => 'branch',
-			),
-			'type'             => array(
-				'property_name' => 'type',
-				'expected'      => array( 'git', 'type' ),
-			),
-			'update-supported' => array(
-				'property_name' => 'update-supported',
-				'expected'      => true,
-			),
-			'requires'         => array(
-				'property_name' => 'requires',
-				'expected'      => 'requires',
-			),
-			'requires_php'     => array(
-				'property_name' => 'requires_php',
-				'expected'      => 'requires_php',
-			),
-			'package'          => array(
-				'property_name' => 'package',
-				'expected'      => 'download_link',
-			),
-			'tested'           => array(
-				'property_name' => 'tested',
-				'expected'      => 'tested',
-			),
-		);
-	}
-
-	/**
-	 * Tests that the theme response is added to no_update when no update is available.
-	 *
-	 * @dataProvider data_theme_no_update_properties
-	 *
-	 * @param string $key_name The name of the property.
-	 * @param string $expected The expected value.
-	 */
-	public function test_should_add_theme_response_to_no_update_when_no_update_is_available( $key_name, $expected ) {
 		$api_data = (object) array(
-			'slug'          => 'test-theme-slug',
-			'file'          => 'my-theme/style.css',
-			'type'          => 'theme',
+			'slug'          => 'test-plugin-slug',
+			'file'          => 'my-plugin/my-plugin.php',
+			'type'          => 'plugin',
 			'url'           => 'http://example.org',
 			'version'       => '0.0.1',
 			'icons'         => (object) array(
@@ -521,6 +421,80 @@ class Lite_UpdateSiteTransientTest extends GitUpdater_UnitTestCase {
 			'tested'        => '10.0.0',
 		);
 
+		return array(
+			'slug'             => array(
+				'property_name' => 'slug',
+				'api_data'      => $api_data,
+				'expected'      => $api_data->slug,
+			),
+			'plugin'           => array(
+				'property_name' => 'plugin',
+				'api_data'      => $api_data,
+				'expected'      => $api_data->file,
+			),
+			'url'              => array(
+				'property_name' => 'url',
+				'api_data'      => $api_data,
+				'expected'      => $api_data->url,
+			),
+			'icons'            => array(
+				'property_name' => 'icons',
+				'api_data'      => $api_data,
+				'expected'      => (array) $api_data->icons,
+			),
+			'banners'          => array(
+				'property_name' => 'banners',
+				'api_data'      => $api_data,
+				'expected'      => $api_data->banners,
+			),
+			'branch'           => array(
+				'property_name' => 'branch',
+				'api_data'      => $api_data,
+				'expected'      => $api_data->branch,
+			),
+			'type'             => array(
+				'property_name' => 'type',
+				'api_data'      => $api_data,
+				'expected'      => "{$api_data->git}-{$api_data->type}",
+			),
+			'update-supported' => array(
+				'property_name' => 'update-supported',
+				'api_data'      => $api_data,
+				'expected'      => true,
+			),
+			'requires'         => array(
+				'property_name' => 'requires',
+				'api_data'      => $api_data,
+				'expected'      => $api_data->requires,
+			),
+			'requires_php'     => array(
+				'property_name' => 'requires_php',
+				'api_data'      => $api_data,
+				'expected'      => $api_data->requires_php,
+			),
+			'package'          => array(
+				'property_name' => 'package',
+				'api_data'      => $api_data,
+				'expected'      => $api_data->download_link,
+			),
+			'tested'           => array(
+				'property_name' => 'tested',
+				'api_data'      => $api_data,
+				'expected'      => $api_data->tested,
+			),
+		);
+	}
+
+	/**
+	 * Tests that the theme response is added to no_update when no update is available.
+	 *
+	 * @dataProvider data_theme_no_update_properties
+	 *
+	 * @param string   $key_name The name of the response key to test.
+	 * @param stdClass $api_data The API data to use.
+	 * @param string   $expected The expected value.
+	 */
+	public function test_should_add_theme_response_to_no_update_when_no_update_is_available( $key_name, $api_data, $expected ) {
 		$lite = new \Fragen\Git_Updater\Lite( $this->test_files['theme'] );
 		$this->set_property_value( $lite, 'api_data', $api_data );
 
@@ -565,24 +539,6 @@ class Lite_UpdateSiteTransientTest extends GitUpdater_UnitTestCase {
 			"The transient's response value does not have a '{$key_name}' key."
 		);
 
-		if ( is_array( $expected ) ) {
-			$expected = implode(
-				'-',
-				array_map(
-					static function ( $key_name ) use ( $api_data ) {
-						return $api_data->$key_name;
-					},
-					$expected
-				)
-			);
-		} elseif ( is_string( $expected ) ) {
-			if ( 'icons' === $expected ) {
-				$expected = (array) $api_data->$expected;
-			} else {
-				$expected = $api_data->$expected;
-			}
-		}
-
 		$this->assertSame(
 			$expected,
 			$actual->no_update[ $api_data->file ][ $key_name ],
@@ -596,54 +552,88 @@ class Lite_UpdateSiteTransientTest extends GitUpdater_UnitTestCase {
 	 * @return array[]
 	 */
 	public function data_theme_no_update_properties() {
+		$api_data = (object) array(
+			'slug'          => 'test-theme-slug',
+			'file'          => 'my-theme/style.css',
+			'type'          => 'theme',
+			'url'           => 'http://example.org',
+			'version'       => '0.0.1',
+			'icons'         => (object) array(
+				'1x' => 'icon-1x.png',
+				'2x' => 'icon-2x.png',
+			),
+			'banners'       => (object) array(
+				'low'  => 'banner-low.png',
+				'high' => 'banner-high.png',
+			),
+			'branch'        => 'test-branch',
+			'git'           => 'test-githost',
+			'requires'      => 'test-version',
+			'requires_php'  => 'test-php-version',
+			'download_link' => 'test-download-link',
+			'tested'        => '10.0.0',
+		);
+
 		return array(
 			'slug'             => array(
 				'key_name' => 'slug',
-				'expected' => 'slug',
+				'api_data' => $api_data,
+				'expected' => $api_data->slug,
 			),
 			'theme'            => array(
 				'key_name' => 'theme',
-				'expected' => 'slug',
+				'api_data' => $api_data,
+				'expected' => $api_data->slug,
 			),
 			'url'              => array(
 				'key_name' => 'url',
-				'expected' => 'url',
+				'api_data' => $api_data,
+				'expected' => $api_data->url,
 			),
 			'icons'            => array(
 				'key_name' => 'icons',
-				'expected' => 'icons',
+				'api_data' => $api_data,
+				'expected' => (array) $api_data->icons,
 			),
 			'banners'          => array(
 				'key_name' => 'banners',
-				'expected' => 'banners',
+				'api_data' => $api_data,
+				'expected' => $api_data->banners,
 			),
 			'branch'           => array(
 				'key_name' => 'branch',
-				'expected' => 'branch',
+				'api_data' => $api_data,
+				'expected' => $api_data->branch,
 			),
 			'type'             => array(
 				'key_name' => 'type',
-				'expected' => array( 'git', 'type' ),
+				'api_data' => $api_data,
+				'expected' => "{$api_data->git}-{$api_data->type}",
 			),
 			'update-supported' => array(
 				'key_name' => 'update-supported',
+				'api_data' => $api_data,
 				'expected' => true,
 			),
 			'requires'         => array(
 				'key_name' => 'requires',
-				'expected' => 'requires',
+				'api_data' => $api_data,
+				'expected' => $api_data->requires,
 			),
 			'requires_php'     => array(
 				'key_name' => 'requires_php',
-				'expected' => 'requires_php',
+				'api_data' => $api_data,
+				'expected' => $api_data->requires_php,
 			),
 			'package'          => array(
 				'property_name' => 'package',
-				'expected'      => 'download_link',
+				'api_data'      => $api_data,
+				'expected'      => $api_data->download_link,
 			),
 			'tested'           => array(
 				'property_name' => 'tested',
-				'expected'      => 'tested',
+				'api_data'      => $api_data,
+				'expected'      => $api_data->tested,
 			),
 		);
 	}


### PR DESCRIPTION
This refactors some `::Update_Site_Transient()` tests to define `$api_data` in the data providers, instead of having the previously awkward test setup I put in.

My bad on that. 😇